### PR TITLE
Native support redirect url

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ export default defineNuxtConfig({
 ```ts
 const oidc = useOidc();
 
-// Invoke login page then redirect to "/profile", default is "/"
+// Invoke login page then redirect to "/profile", override 'redirectUrl' | 'NUXT_OPENID_CONNECT_OP_REDIRECT_URL'
 oidc.login('/profile');
 
-// End session and redirect to "/homepage", default is "/"
+// End session and redirect to "/homepage", override 'redirectLogoutUrl' | 'NUXT_OPENID_CONNECT_OP_REDIRECT_LOGOUT_URL'
 oidc.logout('/homepage');
 
 // Refresh user informations
@@ -106,6 +106,8 @@ oidc.isLoggedIn
 | `clientSecret`      |  `string`  | `''`                                 | Client secret                                                                                                |
 | `callbackUrl`       |  `string`  | `''`                                 | Optional, for custom callback after login                                                                    |
 | `callbackLogoutUrl` |  `string`  | `''`                                 | Optional, for custom callback after logout, same as login by default                                         |
+| `redirectUrl`       |  `string`  | `'/'`                                | For custom redirection after login                                                                           |
+| `redirectLogoutUrl` |  `string`  | `'/'`                                | For custom redirection after logout                                                                          |
 | `scope`             | `string[]` | `[]`                                 | Used during authentication to authorize access to a user's details                                           |
 | **Config**          |            |                                      |                                                                                                              |
 | `debug`             | `boolean`  | `false`                              | Display verbose log on console                                                                               |
@@ -150,11 +152,16 @@ For production, nuxt is generally already built with Nuxt config, and it's not p
 Using runtime config with `.env` vars allow this
 
 ```
-NUXT_OPENID_CONNECT_OP_ISSUER=https://openid.example.com/realms/master
+NUXT_OPENID_CONNECT_OP_ISSUER=https://issuer.example.com/realms/master
 NUXT_OPENID_CONNECT_OP_CLIENT_ID=admin
 NUXT_OPENID_CONNECT_OP_CLIENT_SECRET=1dOuDoUdIdAdAdA2
+
 NUXT_OPENID_CONNECT_OP_CALLBACK_URL=https://nuxt.example.com/oidc/callback
 NUXT_OPENID_CONNECT_OP_CALLBACK_LOGOUT_URL=https://nuxt.example.com/oidc/callback
+
+NUXT_OPENID_CONNECT_OP_REDIRECT_URL=https://nuxt.example.com/profile
+NUXT_OPENID_CONNECT_OP_REDIRECT_LOGOUT_URL=https://nuxt.example.com/homepage
+
 NUXT_OPENID_CONNECT_CONFIG_DEBUG=true
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-openid",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "OpenID-Connect (OIDC) integration module for Nuxt",
   "keywords": [
     "nuxt",

--- a/src/module.ts
+++ b/src/module.ts
@@ -20,6 +20,8 @@ export type OidcProvider = {
   clientSecret: string,
   callbackUrl: string,
   callbackLogoutUrl: string,
+  redirectUrl: string,
+  redirectLogoutUrl: string,
   scope: Array<string>
 }
 
@@ -64,6 +66,8 @@ export default defineNuxtModule<ModuleOptions>({
       clientSecret: '',
       callbackUrl: '',
       callbackLogoutUrl: '',
+      redirectUrl: '/',
+      redirectLogoutUrl: '/',
       scope: [
       ]
     },

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -93,25 +93,36 @@ export class Oidc {
     }
   }
 
-  login(redirect = '/') {
+  login(redirect?: string) {
     if (process.client) {
-      const params = new URLSearchParams({ redirect })
-      const toStr = '/oidc/login?' + params.toString()
-      window.location.replace(toStr)
+      let toStr = '/oidc/login';
+
+      if (redirect) {
+        const params = new URLSearchParams({ redirect });
+
+        toStr += `?${params.toString()}`;
+      }
+
+      window.location.replace(toStr);
     }
   }
 
-  logout(redirect = '/') {
+  logout(redirect?: string) {
     // TODO clear user info when accessToken expired.
     if (process.client) {
-      const params = new URLSearchParams({ redirect })
-      const toStr = '/oidc/logout?' + params.toString()
+      let toStr = '/oidc/logout';
 
-      this.$useState.value.user = {}
-      this.$useState.value.isLoggedIn = false
+      if (redirect) {
+        const params = new URLSearchParams({ redirect });
 
-      this.$storage.removeUserInfo()
-      window.location.replace(toStr)
+        toStr += `?${params.toString()}`;
+      }
+
+      this.$useState.value.user = {};
+      this.$useState.value.isLoggedIn = false;
+
+      this.$storage.removeUserInfo();
+      window.location.replace(toStr);
     }
   }
 }

--- a/src/runtime/server/routes/oidc/callback.ts
+++ b/src/runtime/server/routes/oidc/callback.ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event) => {
 
   deleteCookie(event, config.secret);
 
-  const redirectUrl = getRedirectUrl(req.url);
+  const redirectUrl = getRedirectUrl(req.url, sessionid ? op.redirectUrl : op.redirectLogoutUrl);
 
   const callbackUrl = getCallbackUrl(op.callbackUrl, redirectUrl, req.headers.host);
   const defCallBackUrl = getDefaultBackUrl(redirectUrl, req.headers.host);
@@ -46,7 +46,7 @@ export default defineEventHandler(async (event) => {
     }
 
     await processUserInfo(params.access_token, null, event);
-    res.writeHead(302, { Location: redirectUrl || '/' });
+    res.writeHead(302, { Location: redirectUrl });
     res.end();
   } else if (params.code) {
     // Authorization Code Flow: code -> access_token
@@ -60,7 +60,7 @@ export default defineEventHandler(async (event) => {
       await processUserInfo(tokenSet.access_token, tokenSet, event);
     }
 
-    res.writeHead(302, { Location: redirectUrl || '/' });
+    res.writeHead(302, { Location: redirectUrl });
     res.end();
   } else {
     if (!Object.entries(params).length) {
@@ -68,7 +68,7 @@ export default defineEventHandler(async (event) => {
         console.log('[CALLBACK]: callback redirect');
       }
 
-      res.writeHead(302, { Location: redirectUrl || '/' });
+      res.writeHead(302, { Location: redirectUrl });
     } else if (params.error) {
       // redirct to auth failed error page.
       console.error(`[CALLBACK]: error callback ${params.error}, error_description: ${params.error_description}`);
@@ -79,9 +79,9 @@ export default defineEventHandler(async (event) => {
 
       res.writeHead(302, { Location: '/oidc/cbt?redirect=' + redirectUrl });
     } else {
-      console.error(`[CALLBACK]: error callback ${redirectUrl || '/'}`);
+      console.error(`[CALLBACK]: error callback ${redirectUrl}`);
 
-      res.writeHead(302, { Location: redirectUrl || '/' });
+      res.writeHead(302, { Location: redirectUrl });
     }
 
     res.end();

--- a/src/runtime/server/routes/oidc/login.ts
+++ b/src/runtime/server/routes/oidc/login.ts
@@ -15,7 +15,7 @@ export default defineEventHandler(async (event) => {
   const req = event.node.req;
   const res = event.node.res;
 
-  const redirectUrl = getRedirectUrl(req.url);
+  const redirectUrl = getRedirectUrl(req.url, op.redirectUrl);
   const callbackUrl = getCallbackUrl(op.callbackUrl, redirectUrl, req.headers.host);
   const defCallBackUrl = getDefaultBackUrl(redirectUrl, req.headers.host);
 

--- a/src/runtime/server/routes/oidc/logout.ts
+++ b/src/runtime/server/routes/oidc/logout.ts
@@ -12,7 +12,7 @@ export default defineEventHandler(async (event) => {
     console.log('[LOGOUT]: oidc/logout calling');
   }
 
-  const redirectUrl = getRedirectUrl(req.url);
+  const redirectUrl = getRedirectUrl(req.url, op.redirectLogoutUrl);
   const refreshToken = getCookie(event, config.cookiePrefix + 'refresh_token');
 
   const callbackUrl = getCallbackUrl(op.callbackLogoutUrl, redirectUrl, req.headers.host);

--- a/src/runtime/utils/utils.ts
+++ b/src/runtime/utils/utils.ts
@@ -53,15 +53,15 @@ export const isUnset = (o: unknown): boolean => typeof o === 'undefined' || o ==
 
 export const isSet = (o: unknown): boolean => !isUnset(o);
 
-export const getRedirectUrl = (uri: string | null | undefined): string => {
+export const getRedirectUrl = (uri: string | null | undefined, defaultUri: string = '/'): string => {
   if (!uri) {
-    return '/';
+    return defaultUri;
   }
 
   const idx = uri.indexOf('?');
   const searchParams = new URLSearchParams(idx >= 0 ? uri.substring(idx) : uri);
 
-  return searchParams.get('redirect') || '/';
+  return searchParams.get('redirect') || defaultUri;
 }
 
 export function getCallbackUrl(callbackUrl: string, redirectUrl: string, host: string | undefined): string {


### PR DESCRIPTION
Add Nuxt support for env var redirects URLs

Keep `oidc.login('/profile')` and `oidc.login('/homepage')`, the strongest redirects params for anterior version and better configurability